### PR TITLE
not required cl-lib any more for csound-score.el

### DIFF
--- a/csound-score.el
+++ b/csound-score.el
@@ -27,7 +27,6 @@
 
 ;;; Code:
 
-(require 'cl-lib)
 (require 'csound-font-lock)
 (require 'csound-util)
 (require 'font-lock)
@@ -98,9 +97,8 @@
                 (delete-char spaces-to-add))
               (if before-comment
                   (forward-line)
-                (progn
-                  (setq param-length (skip-chars-forward "^[:space:]"))
-                  (setq index (1+ index)))))))))))
+                (setq param-length (skip-chars-forward "^[:space:]")
+                      index (1+ index))))))))))
 
 
 (defun csound-score-align-block ()


### PR DESCRIPTION
I forgot this change. 'cl-subseq was replaced by 'nthcdr in the last pull, so cl-lib is not required any more in csound-score.el. Not in a hurry.